### PR TITLE
Fix for typo in f18/test-lit/CMakeLists.txt which discard the FLANG_TEST_DEPENDS flag.

### DIFF
--- a/test-lit/CMakeLists.txt
+++ b/test-lit/CMakeLists.txt
@@ -22,7 +22,7 @@ set(FLANG_TEST_DEPENDS
 add_lit_testsuite(check-all "Running the Flang regression tests"
   ${CMAKE_CURRENT_BINARY_DIR}
   PARAMS ${FLANG_TEST_PARAMS}
-  DEPENDS ${FLANG_TEST_DEPENS}
+  DEPENDS ${FLANG_TEST_DEPENDS}
   )
 set_target_properties(check-all PROPERTIES FOLDER "Tests")
 


### PR DESCRIPTION
I think the flag(FLANG_TEST_DEPENDS) may be getting neglected and not checking for dependencies.